### PR TITLE
downlink bitrate

### DIFF
--- a/draft-rw-flow-metadata.md
+++ b/draft-rw-flow-metadata.md
@@ -296,6 +296,10 @@ For either measurement, packets can arrive at the start of a second,
 as near as possible behind each other, and the remaining portion of
 that second could have no packets transmitted.
 
+### Unit
+
+Expressed in Mbps.
+
 ### Host Treatment
 
 The host chooses a video streaming bit rate at or below the signaled rate.


### PR DESCRIPTION
Generalize the metadata as this is not specific to video.  Also, add a provision to communicate the metadata to a remote peer to adjust its behavior.