### PR TITLE
Fix syntax errors in CDDL

### DIFF
--- a/draft-rw-flow-metadata.md
+++ b/draft-rw-flow-metadata.md
@@ -224,17 +224,22 @@ $$metadata-extensions //= (
 
 ; Network Metadata
 
-$$metadata-extensions //= (
-  downlinkBitrate = {
-  nominal: uint,        ; Mbps
-  ? burst-info
-} )
+Bitrate =  {
+  nominal: uint,  ; Mbps
+  ? burst-d => burst-info
+}
 
 burst-info = {
   burst: uint,          ; Mbps
   burstDuration: uint   ; milliseconds
 }
 
+$$metadata-extensions //= (
+   ? downlinkBitrate => Bitrate
+)
+
+downlinkBitrate = "downlinkBitrate"
+burst-d = "burst-info"
 
 ~~~~~
 


### PR DESCRIPTION
The CDDL has syntax errors, fixed it in this PR. You will have to use the steps in https://www.rfc-editor.org/rfc/rfc8610.html#appendix-F to validate the CDDL.